### PR TITLE
방문예정, 완료, my리뷰, 식당리뷰 수정

### DIFF
--- a/src/main/java/com/codechef/codechef/controller/MainController.java
+++ b/src/main/java/com/codechef/codechef/controller/MainController.java
@@ -238,6 +238,7 @@ public class MainController {
 
 
         model.addAttribute("member", memberReviewDTO);
+        log.info("====================="+memberReviewDTO.getReviewRating());
         model.addAttribute("reviews", reviewsPage.getContent());
         model.addAttribute("reviewsPage", reviewsPage);  // 페이지 정보 추가
 

--- a/src/main/java/com/codechef/codechef/dto/MemberReviewDTO.java
+++ b/src/main/java/com/codechef/codechef/dto/MemberReviewDTO.java
@@ -32,6 +32,9 @@ public class MemberReviewDTO {
     }
 
     private static String reviewRating(List<Review> reviewList) {
+        if (reviewList.isEmpty()) {
+            return " "; // 리스트가 비어 있을 경우 기본값 반환
+        }
         // 해당 컬럼의 전체 합을 구하고, 평점 구하기
         int moodTotal = reviewList.stream().mapToInt(Review::getMoodPoint).sum();
         int serveTotal = reviewList.stream().mapToInt(Review::getServePoint).sum();

--- a/src/main/resources/static/css/reviewViewMy.css
+++ b/src/main/resources/static/css/reviewViewMy.css
@@ -65,12 +65,12 @@ body {
     align-items: flex-end; /* 오른쪽 정렬 */
     font-size: 18px;
     margin-right: 30px;
+    text-align:center;
 }
 
 .review-count {
     color: #cccccc;
     font-size: 14px;
-    margin-right: 50px;
     font-weight: 700;
 
 }
@@ -222,5 +222,20 @@ body {
     text-align: right;
     margin: 0;
     margin-left: auto; /* 왼쪽 여백을 자동으로 설정하여 오른쪽으로 밀어냄 */
+}
+
+.review-card2 {
+    display: flex;
+    width: 100%;
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    max-width: 100%; /* 부모 너비에 맞춤 */
+    padding: 20px;
+    margin: 20px 0;
+    border: 1px solid #e0e0e0;
+    justify-content: center; /* 수평 중앙 정렬 */
+    align-items: center; /* 수직 중앙 정렬 */
+
 }
 

--- a/src/main/resources/static/css/reviewViewRes.css
+++ b/src/main/resources/static/css/reviewViewRes.css
@@ -192,3 +192,18 @@ body {
     margin: 0;
     margin-left: auto; /* 왼쪽 여백을 자동으로 설정하여 오른쪽으로 밀어냄 */
 }
+
+.review-card2 {
+    display: flex;
+    width: 100%;
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    max-width: 100%; /* 부모 너비에 맞춤 */
+    padding: 20px;
+    margin: 20px 0;
+    border: 1px solid #e0e0e0;
+    justify-content: center; /* 수평 중앙 정렬 */
+    align-items: center; /* 수직 중앙 정렬 */
+
+}

--- a/src/main/resources/static/css/visit_completion.css
+++ b/src/main/resources/static/css/visit_completion.css
@@ -27,19 +27,26 @@ a { text-decoration: none; color: black; display: flex; flex-direction: row; } a
 
      .main {
         text-align: center;
-     }
-     .main p{
-     font-size : 34px;
+        align-item: center;
+        justify-content: center;
+        display: flex
      }
     p1 {
      font-weight:900px;!important;
     }
+
      .visit_title {
-        padding:5px 10px;
-        border-radius: 20px;
-        margin-top: 70px;
-        border: 1px solid #000;
-        display: inline-block;
+       display: block;
+       padding: 9px 20px;
+       width: 150px;
+       font-size: 20px;
+       font-weight: bold;
+       color: black;
+       border: 3px solid #444444;
+       border-radius: 17px;
+       background-color: #fff;
+       text-align: center; /* 텍스트 중앙 정렬 */
+       margin: 70px 0; /* 위 아래 여백 추가 */
      }
 
      .list_box {
@@ -143,4 +150,13 @@ a { text-decoration: none; color: black; display: flex; flex-direction: row; } a
        color: black;
        text-decoration: none;
    }
+
+    .list_box2 {
+        margin-top: 50px;
+        display: flex;
+        justify-content: center;
+        flex-direction: column; /* 세로로 배치 */
+        align-items: center; /* 수평 중앙 정렬 */
+        text-align: center;
+    }
 

--- a/src/main/resources/static/css/visit_expected.css
+++ b/src/main/resources/static/css/visit_expected.css
@@ -23,14 +23,23 @@ a { text-decoration: none; color: black; } a:visited {color:black}
 
      .main {
         text-align: center;
+        align-item: center;
+        justify-content: center;
+        display: flex
      }
 
-     .visit_title {
-        padding:5px 10px;
-        border-radius: 20px;
-        margin-top: 70px;
-        border: 1px solid #000;
-        display: inline-block;
+    .visit_title {
+       display: block;
+       padding: 9px 20px;
+       width: 150px;
+       font-size: 20px;
+       font-weight: bold;
+       color: black;
+       border: 3px solid #444444;
+       border-radius: 17px;
+       background-color: #fff;
+       text-align: center; /* 텍스트 중앙 정렬 */
+       margin: 70px 0; /* 위 아래 여백 추가 */
      }
 
      .list_box {
@@ -44,7 +53,7 @@ a { text-decoration: none; color: black; } a:visited {color:black}
      }
 
      .res_info{
-        padding-left: 160px;
+        padding-left: 120px;
         display: flex;
         border-width:60%;
         align-items: flex-start;
@@ -95,4 +104,34 @@ a { text-decoration: none; color: black; } a:visited {color:black}
          background: url(/images/main/loc.png) no-repeat 18px #F5F5F5;
          padding-left: 45px;
          font-size: 17px;
+     }
+
+     .btn.letsgomain{
+         display: inline-block; /* 버튼을 블록으로 처리 */
+         justify-content: center; /* 수평 중앙 정렬 */
+         align-items: center; /* 수직 중앙 정렬 */
+         padding: 5px 15px; /* 버튼 안쪽 여백 */
+         border-radius: 9px; /* 모서리 둥글게 */
+         cursor: pointer; /* 커서가 손 모양으로 변경 */
+         text-align: center; /* 중앙 정렬 */
+         align-items: center; /* 수직 중앙 정렬 */
+         white-space: nowrap; /* 줄바꿈 방지 */
+         border: none;
+         background-color: #000;
+         color: #fff;
+         width:245px;
+         margin-top: 20px;
+     }
+
+     .letsgomain h3{
+         margin-bottom: 0; /* p 태그 하단 여백 */
+     }
+
+    .list_box2 {
+        margin-top: 50px;
+        display: flex;
+        justify-content: center;
+        flex-direction: column; /* 세로로 배치 */
+        align-items: center; /* 수평 중앙 정렬 */
+        text-align: center;
      }

--- a/src/main/resources/templates/codechef/reviewViewMy.html
+++ b/src/main/resources/templates/codechef/reviewViewMy.html
@@ -21,7 +21,8 @@
             <div class="review-info">
                 <div class="review-count" th:text="'리뷰 (' + ${reviews.size()} + ')'">리뷰 (0)</div>
                 <div class="rating">
-                    평균 <span class="star">⭐</span> <span th:text="${member.reviewRating}">4.5</span>
+                    평균 <span class="star">⭐</span>
+                    <span th:text="${member.reviewRating}">점수</span>
                 </div>
             </div>
         </div>
@@ -29,7 +30,7 @@
         <!-- 리뷰 카드 섹션 -->
         <div class="reviews-wrapper">
             <!-- 반복되는 리뷰 카드 -->
-            <div th:each="review : ${reviews}" class="review-card">
+            <div th:each="review : ${reviews}" class="review-card" th:if="${#lists.size(reviews) > 0}">
                 <div class="image-container">
                     <img th:src="@{${review.reviewImage}}"
                          alt="요리 이미지"
@@ -59,6 +60,12 @@
                 </div>
 
             </div>
+
+            <!--내 리뷰 없을 때-->
+            <div class="review-card2" th:if="${#lists.isEmpty(reviews)}">
+                <h4>리뷰 내역이 없습니다.</h4>
+            </div>
+
         </div>
     </div>
 

--- a/src/main/resources/templates/codechef/reviewViewRes.html
+++ b/src/main/resources/templates/codechef/reviewViewRes.html
@@ -29,7 +29,7 @@
         <!-- 또리하는 요라이 리뷰 카드 섹션 -->
         <div class="reviews-wrapper">
             <!-- 반복되는 리뷰 카드 -->
-            <div th:each="review : ${reviews}" class="review-card">
+            <div th:each="review : ${reviews}" class="review-card" th:if="${#lists.size(reviews) > 0}">
                 <div class="image-container">
                     <img th:src="@{${review.reviewImage}}"
                          alt="요리 이미지"
@@ -53,6 +53,11 @@
                         <p th:text="${review.contents}">내용</p>
                     </div>
                 </div>
+            </div>
+
+            <!--식당 리뷰 없을 때-->
+            <div class="review-card2" th:if="${#lists.isEmpty(reviews)}">
+                <h4>리뷰 내역이 없습니다.</h4>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/codechef/visit_completion.html
+++ b/src/main/resources/templates/codechef/visit_completion.html
@@ -17,11 +17,12 @@
 <div fragment="content" class="content1">
   <!-- 전체 -->
   <div class="main">
-    <p class="visit_title">방문완료</p>
+    <h1 class="visit_title">방문 완료</h1>
   </div>
 
   <!-- 리스트 -->
-  <div class="list_box">
+  <!--방문 완료 리스트 내역 있을 때-->
+  <div class="list_box" th:if="${#lists.size(reservationsPage.content) > 0}">
     <ul id="reservation-list">
       <div th:each="reservation : ${reservationsPage.content}">
         <!-- 리뷰 작성 대기 내역 (visitOx가 true이고 reviewOx가 false일 때) -->
@@ -84,6 +85,11 @@
         </li>
       </div>
     </ul>
+  </div>
+
+  <!-- 방문 완료 리스트 내역 없을 때 -->
+  <div class="list_box2" th:if="${#lists.isEmpty(reservationsPage.content)}">
+    <h4>방문 완료 내역이 없습니다.</h4>
   </div>
 </div>
 <nav aria-label="Page navigation example" th:unless="${reservationsPage.totalElements == 0}">

--- a/src/main/resources/templates/codechef/visit_expected.html
+++ b/src/main/resources/templates/codechef/visit_expected.html
@@ -38,11 +38,11 @@
     <div class="content"> <!-- 전체 -->
 
         <div class="main">
-            <p4 class="visit_title">
-                방문예정</p4>
+            <h1 class="visit_title">방문 예정</h1>
         </div>
 
-        <div class="list_box">
+        <!-- 방문 예정 내역 있을 때 -->
+        <div class="list_box" th:if="${#lists.size(visitExpected) > 0}">
             <ul>
                 <li th:each="visitExpected : ${visitExpected}">
                     <!-- 첫번째 박스 -->
@@ -60,9 +60,7 @@
                                 <p2 th:text="${#dates.format(visitExpected.reservationDate, 'yyyy.MM.dd')}">2024.10.22 - 14:02</p2>
                                 <p2>방문예정</p2>
                             </div>
-
                         </div>
-
                     </div>
 
 
@@ -74,16 +72,14 @@
                         <h4>취소</h4>
                     </button>
                 </li>
-
             </ul>
-
-
-
         </div>
 
-
-
-
+        <!-- 방문 예정 내역 없을 때 -->
+        <div class="list_box2" th:if="${#lists.isEmpty(visitExpected)}">
+            <h5>방문 예정 내역이 없습니다.</h5>
+            <a class="btn letsgomain" th:href="@{/main}"><h3>식당 예약하러 가기!</h3></a>
+        </div>
 
     </div>
     <nav aria-label="Page navigation example" th:unless="${page.totalElements == 0}">


### PR DESCRIPTION
1. 방문 예정 리스트 페이지에서 이미지와 식당 이름의 간격 좁히기 (css)
2. mypage에서 방문 예정, 방문 완료, my 작성 리뷰 보기 페이지 눌렀을 때 아무 정보 없으면 '내역 없음' 텍스트 띄우기, 방문 예정은 main 가는 버튼 띄우기
3. 방문 예정, 완료 title을 통일감있게 수정